### PR TITLE
remove Map and polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,24 +19,25 @@ import ptBr from "./src/locale/pt-BR.js";
 import ruRu from "./src/locale/ru-RU.js";
 import zhCn from "./src/locale/zh-CN.js";
 
-var localeDefinitions = (new Map)
-    .set("ca-ES", caEs)
-    .set("de-DE", deDe)
-    .set("en-CA", enCa)
-    .set("en-GB", enGb)
-    .set("en-US", enUs)
-    .set("es-ES", esEs)
-    .set("fi-FI", fiFi)
-    .set("fr-CA", frCa)
-    .set("fr-FR", frFr)
-    .set("he-IL", heIl)
-    .set("it-IT", itIt)
-    .set("mk-MK", mkMk)
-    .set("nl-NL", nlNl)
-    .set("pl-PL", plPl)
-    .set("pt-BR", ptBr)
-    .set("ru-RU", ruRu)
-    .set("zh-CN", zhCn);
+var localeDefinitions = {
+    "ca-ES": caEs,
+    "de-DE": deDe,
+    "en-CA": enCa,
+    "en-GB": enGb,
+    "en-US": enUs,
+    "es-ES": esEs,
+    "fi-FI": fiFi,
+    "fr-CA": frCa,
+    "fr-FR": frFr,
+    "he-IL": heIl,
+    "it-IT": itIt,
+    "mk-MK": mkMk,
+    "nl-NL": nlNl,
+    "pl-PL": plPl,
+    "pt-BR": ptBr,
+    "ru-RU": ruRu,
+    "zh-CN": zhCn
+};
 
 var defaultLocale = locale(enUs);
 export var format = defaultLocale.format;
@@ -44,7 +45,7 @@ export var utcFormat = defaultLocale.utcFormat;
 
 export function localeFormat(definition) {
   if (typeof definition === "string") {
-    definition = localeDefinitions.get(definition);
+    definition = localeDefinitions[definition];
     if (!definition) return null;
   }
   return locale(definition);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/d3/d3-time-format.git"
   },
   "scripts": {
-    "pretest": "mkdir -p build && d3-bundler --polyfill-map --format=umd --name=timeFormat -- index.js > build/timeFormat.js",
+    "pretest": "mkdir -p build && d3-bundler --format=umd --name=timeFormat -- index.js > build/timeFormat.js",
     "test": "TZ=America/Los_Angeles faucet `find test -name '*-test.js'`",
     "prepublish": "npm run test && uglifyjs build/timeFormat.js -c -m -o build/timeFormat.min.js && rm -f build/timeFormat.zip && zip -j build/timeFormat.zip -- LICENSE README.md build/timeFormat.js build/timeFormat.min.js"
   },

--- a/src/locale.js
+++ b/src/locale.js
@@ -214,22 +214,22 @@ export default function(locale) {
 
   function parseShortWeekday(d, string, i) {
     var n = shortWeekdayRe.exec(string.slice(i));
-    return n ? (d.w = shortWeekdayLookup.get(n[0].toLowerCase()), i + n[0].length) : -1;
+    return n ? (d.w = shortWeekdayLookup[n[0].toLowerCase()], i + n[0].length) : -1;
   }
 
   function parseWeekday(d, string, i) {
     var n = weekdayRe.exec(string.slice(i));
-    return n ? (d.w = weekdayLookup.get(n[0].toLowerCase()), i + n[0].length) : -1;
+    return n ? (d.w = weekdayLookup[n[0].toLowerCase()], i + n[0].length) : -1;
   }
 
   function parseShortMonth(d, string, i) {
     var n = shortMonthRe.exec(string.slice(i));
-    return n ? (d.m = shortMonthLookup.get(n[0].toLowerCase()), i + n[0].length) : -1;
+    return n ? (d.m = shortMonthLookup[n[0].toLowerCase()], i + n[0].length) : -1;
   }
 
   function parseMonth(d, string, i) {
     var n = monthRe.exec(string.slice(i));
-    return n ? (d.m = monthLookup.get(n[0].toLowerCase()), i + n[0].length) : -1;
+    return n ? (d.m = monthLookup[n[0].toLowerCase()], i + n[0].length) : -1;
   }
 
   function parseLocaleDateTime(d, string, i) {
@@ -245,7 +245,7 @@ export default function(locale) {
   }
 
   function parsePeriod(d, string, i) {
-    var n = periodLookup.get(string.slice(i, i += 2).toLowerCase());
+    var n = periodLookup[string.slice(i, i += 2).toLowerCase()];
     return n == null ? -1 : (d.p = n, i);
   }
 
@@ -326,8 +326,8 @@ function formatRe(names) {
 }
 
 function formatLookup(names) {
-  var map = new Map, i = -1, n = names.length;
-  while (++i < n) map.set(names[i].toLowerCase(), i);
+  var map = Object.create(null), i = -1, n = names.length;
+  while (++i < n) map[names[i].toLowerCase()] = i;
   return map;
 }
 


### PR DESCRIPTION
cc/ @mbostock 

Hi there!

We're starting to rely on several of your modules for some open source work, and the Map polyfill is a real thorn in our side. The Map polyfill included in `d3-bundler` is not working, and we don't want to add the overhead of including our own.  We are also writing all es6, but shying away from things that don't easily transpile (i.e. Map).  Since you're still using strings for keys, we're hoping to convince you to drop Map in favor of plain objects.  This PR does exactly that.  All tests pass.

Thanks!
FormidableLabs