### PR TITLE
Modify time zone parsing (%Z) to accept any ISO 8601 compatible time zone format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Returns a new [*format* function](#_format) for the given string *specifier*. Th
 * `%X` - the locale’s time, such as `%H:%M:%S`.*
 * `%y` - year without century as a decimal number [00,99].
 * `%Y` - year with century as a decimal number.
-* `%Z` - time zone offset, such as `-0700`.
+* `%Z` - time zone offset, such as `-0700`, `-07:00`, `-07`, or `Z`.
 * `%%` - a literal percent sign (`%`).
 
 Directives marked with an asterisk (*) may be affected by the [locale definition](#localeFormat). For `%U`, all days in a new year preceding the first Sunday are considered to be in week 0. For `%W`, all days in a new year preceding the first Monday are considered to be in week 0. Week numbers are computed using [*interval*.count](https://github.com/d3/d3-time#interval_count).

--- a/src/locale.js
+++ b/src/locale.js
@@ -357,9 +357,14 @@ function parseYear(d, string, i) {
 }
 
 function parseZone(d, string, i) {
-  return /^[+-]\d{4}$/.test(string = string.slice(i, i + 5))
-      ? (d.Z = -string, i + 5) // sign differs from getTimezoneOffset!
-      : -1;
+  var n = /^(Z)|([+-]\d\d)(?:\:?(\d\d))?/.exec(string.slice(i));
+  if (n) {
+    d.Z = n[1]
+        ? 0
+        : -(n[2] + (n[3] || "00")); // sign differs from getTimezoneOffset!
+    return i + n[0].length;
+  }
+  return -1;
 }
 
 function parseMonthNumber(d, string, i) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -357,11 +357,11 @@ function parseYear(d, string, i) {
 }
 
 function parseZone(d, string, i) {
-  var n = /^(Z)|([+-]\d\d)(?:\:?(\d\d))?/.exec(string.slice(i));
+  var n = /^(Z)|([+-]\d\d)(?:\:?(\d\d))?/.exec(string.slice(i, i + 6));
   if (n) {
-    d.Z = n[1]
-        ? 0
-        : -(n[2] + (n[3] || "00")); // sign differs from getTimezoneOffset!
+    d.Z = n[1] ? 0              // 'Z' for UTC
+        : n[3] ? -(n[2] + n[3]) // sign differs from getTimezoneOffset!
+               : -n[2] * 100;
     return i + n[0].length;
   }
   return -1;

--- a/test/format-parse-test.js
+++ b/test/format-parse-test.js
@@ -173,6 +173,26 @@ tape("format(\"%m/%d/%Y %Z\").parse(date) parses timezone offset", function(test
   test.end();
 });
 
+tape("format(\"%m/%d/%Y %Z\").parse(date) parses timezone offset in the form '+-hh:mm'", function(test) {
+  var p = timeFormat.format("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 +01:30"), date.local(1990, 0, 1, 14, 30));
+  test.deepEqual(p("01/02/1990 -01:30"), date.local(1990, 0, 1, 17, 30));
+  test.end();
+});
+
+tape("format(\"%m/%d/%Y %Z\").parse(date) parses timezone offset in the form '+-hh'", function(test) {
+  var p = timeFormat.format("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 +01"), date.local(1990, 0, 1, 15));
+  test.deepEqual(p("01/02/1990 -01"), date.local(1990, 0, 1, 17));
+  test.end();
+});
+
+tape("format(\"%m/%d/%Y %Z\").parse(date) parses timezone offset in the form 'Z'", function(test) {
+  var p = timeFormat.format("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 Z"), date.local(1990, 0, 1, 16));
+  test.end();
+});
+
 tape("format(\"%-m/%0d/%_Y\").parse(date) ignores optional padding modifier, skipping zeroes and spaces", function(test) {
   var p = timeFormat.format("%-m/%0d/%_Y").parse;
   test.deepEqual(p("01/ 1/1990"), date.local(1990, 0, 1));

--- a/test/utcFormat-parse-test.js
+++ b/test/utcFormat-parse-test.js
@@ -98,3 +98,23 @@ tape("utcFormat(\"\").parse(date) parses timezone offset", function(test) {
   test.deepEqual(p("01/02/1990 -0800"), date.local(1990, 0, 2));
   test.end();
 });
+
+tape("utcFormat(\"\").parse(date) parses timezone offset (in the form '+-hh:mm')", function(test) {
+  var p = timeFormat.utcFormat("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 +01:30"), date.utc(1990, 0, 1, 22, 30));
+  test.deepEqual(p("01/02/1990 -01:30"), date.utc(1990, 0, 2, 1, 30));
+  test.end();
+});
+
+tape("utcFormat(\"\").parse(date) parses timezone offset (in the form '+-hh')", function(test) {
+  var p = timeFormat.utcFormat("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 +01"), date.utc(1990, 0, 1, 23));
+  test.deepEqual(p("01/02/1990 -01"), date.utc(1990, 0, 2, 1));
+  test.end();
+});
+
+tape("utcFormat(\"\").parse(date) parses timezone offset (in the form 'Z')", function(test) {
+  var p = timeFormat.utcFormat("%m/%d/%Y %Z").parse;
+  test.deepEqual(p("01/02/1990 Z"), date.utc(1990, 0, 2));
+  test.end();
+});


### PR DESCRIPTION
This is a port of a pull request from the single-module version of D3 3.x (https://github.com/mbostock/d3/pull/2480). I hadn’t realized the work of splitting up modules was happening at the time I proposed it. Let me know if this is unwelcome or not helpful.

This includes parsing support for:
  * +-hhmm (the only previously accepted format)
  * +-hh:mm
  * +-hh
  * Z (for UTC)

…and addresses an old issue that myself and several others have run into: https://github.com/mbostock/d3/issues/2055