### PR TITLE
Fix #24 - %f for microseconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Returns a new formatter for the given string *specifier*. The specifier string m
 * `%c` - the locale’s date and time, such as `%a %b %e %H:%M:%S %Y`.*
 * `%d` - zero-padded day of the month as a decimal number [01,31].
 * `%e` - space-padded day of the month as a decimal number [ 1,31]; equivalent to `%_d`.
+* `%f` - microseconds as a decimal number [000000, 999999].
 * `%H` - hour (24-hour clock) as a decimal number [00,23].
 * `%I` - hour (12-hour clock) as a decimal number [01,12].
 * `%j` - day of the year as a decimal number [001,366].

--- a/src/locale.js
+++ b/src/locale.js
@@ -51,6 +51,7 @@ export default function formatLocale(locale) {
     "c": null,
     "d": formatDayOfMonth,
     "e": formatDayOfMonth,
+    "f": formatMicroseconds,
     "H": formatHour24,
     "I": formatHour12,
     "j": formatDayOfYear,
@@ -78,6 +79,7 @@ export default function formatLocale(locale) {
     "c": null,
     "d": formatUTCDayOfMonth,
     "e": formatUTCDayOfMonth,
+    "f": formatUTCMicroseconds,
     "H": formatUTCHour24,
     "I": formatUTCHour12,
     "j": formatUTCDayOfYear,
@@ -105,6 +107,7 @@ export default function formatLocale(locale) {
     "c": parseLocaleDateTime,
     "d": parseDayOfMonth,
     "e": parseDayOfMonth,
+    "f": parseMicroseconds,
     "H": parseHour24,
     "I": parseHour24,
     "j": parseDayOfYear,
@@ -404,6 +407,11 @@ function parseMilliseconds(d, string, i) {
   return n ? (d.L = +n[0], i + n[0].length) : -1;
 }
 
+function parseMicroseconds(d, string, i) {
+  var n = numberRe.exec(string.slice(i, i + 6));
+  return n ? (d.L = Math.floor(n[0] / 1000), i + n[0].length) : -1;
+}
+
 function parseLiteralPercent(d, string, i) {
   var n = percentRe.exec(string.slice(i, i + 1));
   return n ? i + n[0].length : -1;
@@ -427,6 +435,10 @@ function formatDayOfYear(d, p) {
 
 function formatMilliseconds(d, p) {
   return pad(d.getMilliseconds(), p, 3);
+}
+
+function formatMicroseconds(d, p) {
+  return formatMilliseconds(d, p) + "000";
 }
 
 function formatMonthNumber(d, p) {
@@ -486,6 +498,10 @@ function formatUTCDayOfYear(d, p) {
 
 function formatUTCMilliseconds(d, p) {
   return pad(d.getUTCMilliseconds(), p, 3);
+}
+
+function formatUTCMicroseconds(d, p) {
+  return formatUTCMilliseconds(d, p) + "000";
 }
 
 function formatUTCMonthNumber(d, p) {

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -191,6 +191,13 @@ tape("timeFormat(\"%L\")(date) formats zero-padded milliseconds", function(test)
   test.end();
 });
 
+tape("timeFormat(\"%f\")(date) formats zero-padded microseconds", function(test) {
+  var f = timeFormat.timeFormat("%f");
+  test.equal(f(date.local(1990, 0, 1, 0, 0, 0,   0)), "000000");
+  test.equal(f(date.local(1990, 0, 1, 0, 0, 0, 432)), "432000");
+  test.end();
+});
+
 tape("timeFormat(\"%U\")(date) formats zero-padded week numbers", function(test) {
   var f = timeFormat.timeFormat("%U");
   test.equal(f(date.local(1990,  0,  1,  0)), "00");

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -169,6 +169,18 @@ tape("timeParse(\"%X\")(date) parses locale time", function(test) {
   test.end();
 });
 
+tape("timeParse(\"%L\")(date) parses milliseconds", function(test) {
+  var p = timeFormat.timeParse("%L");
+  test.deepEqual(p("432"), date.local(1900, 0, 1, 0, 0, 0, 432));
+  test.end();
+});
+
+tape("timeParse(\"%f\")(date) parses microseconds", function(test) {
+  var p = timeFormat.timeParse("%f");
+  test.deepEqual(p("432000"), date.local(1900, 0, 1, 0, 0, 0, 432));
+  test.end();
+});
+
 tape("timeParse(\"%I:%M:%S %p\")(date) parses twelve hour, minute and second", function(test) {
   var p = timeFormat.timeParse("%I:%M:%S %p");
   test.deepEqual(p("12:00:00 am"), date.local(1900, 0, 1, 0, 0, 0));

--- a/test/utcFormat-test.js
+++ b/test/utcFormat-test.js
@@ -179,6 +179,13 @@ tape("utcFormat(\"%L\")(date) formats zero-padded milliseconds", function(test) 
   test.end();
 });
 
+tape("utcFormat(\"%f\")(date) formats zero-padded microseconds", function(test) {
+  var f = timeFormat.utcFormat("%f");
+  test.equal(f(date.utc(1990, 0, 1, 0, 0, 0,   0)), "000000");
+  test.equal(f(date.utc(1990, 0, 1, 0, 0, 0, 432)), "432000");
+  test.end();
+});
+
 tape("utcFormat(\"%U\")(date) formats zero-padded week numbers", function(test) {
   var f = timeFormat.utcFormat("%U");
   test.equal(f(date.utc(1990,  0,  1,  0)), "00");

--- a/test/utcParse-test.js
+++ b/test/utcParse-test.js
@@ -76,6 +76,18 @@ tape("utcParse(\"\")(date) parses locale time", function(test) {
   test.end();
 });
 
+tape("utcParse(\"%L\")(date) parses milliseconds", function(test) {
+  var p = timeFormat.utcParse("%L");
+  test.deepEqual(p("432"), date.utc(1900, 0, 1, 0, 0, 0, 432));
+  test.end();
+});
+
+tape("utcParse(\"%f\")(date) parses microseconds", function(test) {
+  var p = timeFormat.utcParse("%f");
+  test.deepEqual(p("432000"), date.utc(1900, 0, 1, 0, 0, 0, 432));
+  test.end();
+});
+
 tape("utcParse(\"\")(date) parses twelve hour, minute and second", function(test) {
   var p = timeFormat.utcParse("%I:%M:%S %p");
   test.deepEqual(p("12:00:00 am"), date.utc(1900, 0, 1, 0, 0, 0));


### PR DESCRIPTION
The `%f` is adopted from Python.
