### PR TITLE
Implement ISO week number (%V)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Returns a new formatter for the given string *specifier*. The specifier string m
 * `%p` - either AM or PM.*
 * `%S` - second as a decimal number [00,61].
 * `%U` - Sunday-based week of the year as a decimal number [00,53].
+* `%V` - ISO 8601 week number of the year as a decimal number [01, 53].
 * `%w` - Sunday-based weekday as a decimal number [0,6].
 * `%W` - Monday-based week of the year as a decimal number [00,53].
 * `%x` - the locale’s date, such as `%-m/%-d/%Y`.*
@@ -130,7 +131,10 @@ Returns a new formatter for the given string *specifier*. The specifier string m
 
 Directives marked with an asterisk (*) may be affected by the [locale definition](#localeFormat).
 
-For `%U`, all days in a new year preceding the first Sunday are considered to be in week 0. For `%W`, all days in a new year preceding the first Monday are considered to be in week 0. Week numbers are computed using [*interval*.count](https://github.com/d3/d3-time/blob/master/README.md#interval_count). For example, 2015-52 and 2016-00 represent Monday, December 28, 2015, while 2015-53 and 2016-01 represent Monday, January 4, 2016. This differs from the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date) specification, which uses a more complicated definition!
+For `%U`, all days in a new year preceding the first Sunday are considered to be in week 0. For `%W`, all days in a new year preceding the first Monday are considered to be in week 0. Week numbers are computed using [*interval*.count](https://github.com/d3/d3-time/blob/master/README.md#interval_count). For example, 2015-52 and 2016-00 represent Monday, December 28, 2015, while 2015-53 and 2016-01 represent Monday, January 4, 2016. This differs from the [ISO week date](https://en.wikipedia.org/wiki/ISO_week_date) specification (`%V`), which uses a more complicated definition!
+
+For `%V`, see the [strftime man page](http://man7.org/linux/man-pages/man3/strftime.3.html):
+> In this system, weeks start on a Monday, and are numbered from 01, for the first week, up to 52 or 53, for the last week.  Week 1 is the first week where four or more days fall within the new year (or, synonymously, week 01 is: the first week of the year that contains a Thursday; or, the week that has 4 January in it).
 
 The `%` sign indicating a directive may be immediately followed by a padding modifier:
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,4 +1,15 @@
-import {timeDay, timeSunday, timeMonday, timeYear, utcDay, utcSunday, utcMonday, utcYear} from "d3-time";
+import {
+  timeDay,
+  timeSunday,
+  timeMonday,
+  timeThursday,
+  timeYear,
+  utcDay,
+  utcSunday,
+  utcMonday,
+  utcThursday,
+  utcYear
+} from 'd3-time';
 
 function localDate(d) {
   if (0 <= d.y && d.y < 100) {
@@ -60,6 +71,7 @@ export default function formatLocale(locale) {
     "p": formatPeriod,
     "S": formatSeconds,
     "U": formatWeekNumberSunday,
+    'V': formatWeekNumberISO,
     "w": formatWeekdayNumber,
     "W": formatWeekNumberMonday,
     "x": null,
@@ -87,6 +99,7 @@ export default function formatLocale(locale) {
     "p": formatUTCPeriod,
     "S": formatUTCSeconds,
     "U": formatUTCWeekNumberSunday,
+    "V": formatUTCWeekNumberISO,
     "w": formatUTCWeekdayNumber,
     "W": formatUTCWeekNumberMonday,
     "x": null,
@@ -445,6 +458,16 @@ function formatWeekNumberSunday(d, p) {
   return pad(timeSunday.count(timeYear(d), d), p, 2);
 }
 
+function formatWeekNumberISO(d, p) {
+  var dow = d.getDay();
+  d = (dow >= 4 || dow === 0) ? timeThursday(d) : timeThursday.ceil(d);
+  var weekNum = timeThursday.count(timeYear(d), d);
+  if (timeYear(d).getDay() === 4) {
+    weekNum++;
+  }
+  return pad(weekNum, p, 2);
+}
+
 function formatWeekdayNumber(d) {
   return d.getDay();
 }
@@ -502,6 +525,16 @@ function formatUTCSeconds(d, p) {
 
 function formatUTCWeekNumberSunday(d, p) {
   return pad(utcSunday.count(utcYear(d), d), p, 2);
+}
+
+function formatUTCWeekNumberISO(d, p) {
+  var dow = d.getUTCDay();
+  d = (dow >= 4 || dow === 0) ? utcThursday(d) : utcThursday.ceil(d);
+  var weekNum = utcThursday.count(utcYear(d), d);
+  if (utcYear(d).getUTCDay() === 4) {
+    weekNum++;
+  }
+  return pad(weekNum, p, 2);
 }
 
 function formatUTCWeekdayNumber(d) {

--- a/src/locale.js
+++ b/src/locale.js
@@ -380,17 +380,17 @@ function parseWeekdayNumber(d, string, i) {
 }
 
 function parseWeekNumberSunday(d, string, i) {
-  var n = numberRe.exec(string.slice(i));
+  var n = numberRe.exec(string.slice(i, i + 2));
   return n ? (d.U = +n[0], i + n[0].length) : -1;
 }
 
 function parseWeekNumberISO(d, string, i) {
-  var n = numberRe.exec(string.slice(i));
+  var n = numberRe.exec(string.slice(i, i + 2));
   return n ? (d.V = +n[0], i + n[0].length) : -1;
 }
 
 function parseWeekNumberMonday(d, string, i) {
-  var n = numberRe.exec(string.slice(i));
+  var n = numberRe.exec(string.slice(i, i + 2));
   return n ? (d.W = +n[0], i + n[0].length) : -1;
 }
 

--- a/src/locale.js
+++ b/src/locale.js
@@ -184,32 +184,30 @@ export default function formatLocale(locale) {
       if ("p" in d) d.H = d.H % 12 + d.p * 12;
 
       // Convert day-of-week and week-of-year to day-of-year.
-      if ("W" in d || "U" in d || "V" in d) {
-        if ("V" in d) {
-          if (d.V < 1 || d.V > 53) return null;
-          // fall back to the start of the week (Monday) if no day-of-week is given
-          if (!("w" in d)) d.w = 1;
-          if ("Z" in d) {
-            var isod_Z = utcDate(newYear(d.y)), dow_Z = isod_Z.getUTCDay();
-            isod_Z = dow_Z > 4 || dow_Z === 0 ? utcMonday.ceil(isod_Z) : utcMonday(isod_Z);
-            isod_Z = utcDay.offset(isod_Z, (d.V - 1) * 7);
-            d.y = isod_Z.getUTCFullYear();
-            d.m = isod_Z.getUTCMonth();
-            d.d = isod_Z.getUTCDate() + (d.w + 6) % 7;
-          } else {
-            var isod = newDate(newYear(d.y)), dow = isod.getDay();
-            isod = dow > 4 || dow === 0 ? timeMonday.ceil(isod) : timeMonday(isod);
-            isod = timeDay.offset(isod, (d.V - 1) * 7);
-            d.y = isod.getFullYear();
-            d.m = isod.getMonth();
-            d.d = isod.getDate() + (d.w + 6) % 7;
-          }
+      if ("V" in d) {
+        if (d.V < 1 || d.V > 53) return null;
+        // fall back to the start of the week (Monday) if no day-of-week is given
+        if (!("w" in d)) d.w = 1;
+        if ("Z" in d) {
+          var isod_Z = utcDate(newYear(d.y)), dow_Z = isod_Z.getUTCDay();
+          isod_Z = dow_Z > 4 || dow_Z === 0 ? utcMonday.ceil(isod_Z) : utcMonday(isod_Z);
+          isod_Z = utcDay.offset(isod_Z, (d.V - 1) * 7);
+          d.y = isod_Z.getUTCFullYear();
+          d.m = isod_Z.getUTCMonth();
+          d.d = isod_Z.getUTCDate() + (d.w + 6) % 7;
         } else {
-          if (!("w" in d)) d.w = "W" in d ? 1 : 0;
-          var day = "Z" in d ? utcDate(newYear(d.y)).getUTCDay() : newDate(newYear(d.y)).getDay();
-          d.m = 0;
-          d.d = "W" in d ? (d.w + 6) % 7 + d.W * 7 - (day + 5) % 7 : d.w + d.U * 7 - (day + 6) % 7;
+          var isod = newDate(newYear(d.y)), dow = isod.getDay();
+          isod = dow > 4 || dow === 0 ? timeMonday.ceil(isod) : timeMonday(isod);
+          isod = timeDay.offset(isod, (d.V - 1) * 7);
+          d.y = isod.getFullYear();
+          d.m = isod.getMonth();
+          d.d = isod.getDate() + (d.w + 6) % 7;
         }
+      } else if ("W" in d || "U" in d) {
+        if (!("w" in d)) d.w = "W" in d ? 1 : 0;
+        var day = "Z" in d ? utcDate(newYear(d.y)).getUTCDay() : newDate(newYear(d.y)).getDay();
+        d.m = 0;
+        d.d = "W" in d ? (d.w + 6) % 7 + d.W * 7 - (day + 5) % 7 : d.w + d.U * 7 - (day + 6) % 7;
       }
 
       // If a time zone is specified, all fields are interpreted as UTC and then

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -204,6 +204,21 @@ tape("timeFormat(\"%U\")(date) formats zero-padded week numbers", function(test)
   test.end();
 });
 
+tape("timeFormat(\"%V\")(date) formats zero-padded ISO 8601 week numbers", function(test) {
+  var f = timeFormat.timeFormat("%V");
+  test.equal(f(date.local(1990,  0,  1,  0)), "01");
+  test.equal(f(date.local(1990,  5,  1,  0)), "22");
+  test.equal(f(date.local(2010,  2, 13, 23)), "10");
+  test.equal(f(date.local(2010,  2, 14,  0)), "10"); // DST begins
+  test.equal(f(date.local(2010,  2, 15,  0)), "11");
+  test.equal(f(date.local(2010, 10,  6, 23)), "44");
+  test.equal(f(date.local(2010, 10,  7,  0)), "44"); // DST ends
+  test.equal(f(date.local(2010, 10,  8,  0)), "45");
+  test.equal(f(date.local(2015, 11,  31, 0)), "53");
+  test.equal(f(date.local(2016,  0,  1,  0)), "53");
+  test.end();
+});
+
 tape("timeFormat(\"%x\")(date) formats localized dates", function(test) {
   var f = timeFormat.timeFormat("%x");
   test.equal(f(date.local(1990, 0, 1)), "1/1/1990");

--- a/test/parse-test.js
+++ b/test/parse-test.js
@@ -66,6 +66,17 @@ tape("timeParse(\"%w %U %Y\")(date) parses numeric weekday, week number (Sunday)
   test.end();
 });
 
+tape("timeParse(\"%w %V %Y\")(date) parses numeric weekday, week number (ISO) and year", function(test) {
+  var p = timeFormat.timeParse("%w %V %Y");
+  test.deepEqual(p("1 01 1990"), date.local(1990,  0,  1));
+  test.deepEqual(p("0 05 1991"), date.local(1991,  1,  3));
+  test.deepEqual(p("4 53 1992"), date.local(1992, 11, 31));
+  test.deepEqual(p("0 52 1994"), date.local(1995,  0,  1));
+  test.deepEqual(p("0 01 1995"), date.local(1995,  0,  8));
+  test.equal(p("X 03 2010"), null);
+  test.end();
+});
+
 tape("timeParse(\"%W %Y\")(date) parses week number (Monday) and year", function(test) {
   var p = timeFormat.timeParse("%W %Y");
   test.deepEqual(p("01 1990"), date.local(1990,  0,  1));

--- a/test/utcFormat-test.js
+++ b/test/utcFormat-test.js
@@ -192,6 +192,21 @@ tape("utcFormat(\"%U\")(date) formats zero-padded week numbers", function(test) 
   test.end();
 });
 
+tape("utcFormat(\"%V\")(date) formats zero-padded ISO 8601 week numbers", function(test) {
+  var f = timeFormat.utcFormat("%V");
+  test.equal(f(date.utc(1990,  0,  1,  0)), "01");
+  test.equal(f(date.utc(1990,  5,  1,  0)), "22");
+  test.equal(f(date.utc(2010,  2, 13, 23)), "10");
+  test.equal(f(date.utc(2010,  2, 14,  0)), "10"); // DST begins
+  test.equal(f(date.utc(2010,  2, 15,  0)), "11");
+  test.equal(f(date.utc(2010, 10,  6, 23)), "44");
+  test.equal(f(date.utc(2010, 10,  7,  0)), "44"); // DST ends
+  test.equal(f(date.utc(2010, 10,  8,  0)), "45");
+  test.equal(f(date.utc(2015, 11,  31, 0)), "53");
+  test.equal(f(date.utc(2016,  0,  1,  0)), "53");
+  test.end();
+});
+
 tape("utcFormat(\"%x\")(date) formats localized dates", function(test) {
   var f = timeFormat.utcFormat("%x");
   test.equal(f(date.utc(1990, 0, 1)), "1/1/1990");

--- a/test/utcParse-test.js
+++ b/test/utcParse-test.js
@@ -114,3 +114,27 @@ tape("utcParse(\"\")(date) parses timezone offset (in the form 'Z')", function(t
   test.deepEqual(p("01/02/1990 Z"), date.utc(1990, 0, 2));
   test.end();
 });
+
+tape("utcParse(\"%w %V %Y\")(date) parses numeric weekday, week number (ISO) and year", function(test) {
+  var p = timeFormat.timeParse("%w %V %Y %Z");
+  test.deepEqual(p("1 01 1990 Z"), date.utc(1990,  0,  1));
+  test.deepEqual(p("0 05 1991 Z"), date.utc(1991,  1,  3));
+  test.deepEqual(p("4 53 1992 Z"), date.utc(1992, 11, 31));
+  test.deepEqual(p("0 52 1994 Z"), date.utc(1995,  0,  1));
+  test.deepEqual(p("0 01 1995 Z"), date.utc(1995,  0,  8));
+  test.equal(p("X 03 2010"), null);
+  test.end();
+});
+
+tape("utcParse(\"%V %Y\")(date) week number (ISO) and year", function(test) {
+  var p = timeFormat.timeParse("%V %Y %Z");
+  test.deepEqual(p("01 1990 Z"), date.utc(1990,  0,  1));
+  test.deepEqual(p("05 1991 Z"), date.utc(1991,  0, 28));
+  test.deepEqual(p("53 1992 Z"), date.utc(1992, 11, 28));
+  test.deepEqual(p("01 1993 Z"), date.utc(1993,  0,  4));
+  test.deepEqual(p("01 1995 Z"), date.utc(1995,  0,  2));
+  test.deepEqual(p("00 1995 Z"), null);
+  test.deepEqual(p("54 1995 Z"), null);
+  test.deepEqual(p("X 1995 Z"), null);
+  test.end();
+});


### PR DESCRIPTION
This is based off of the logic in https://github.com/d3/d3/pull/2151 and would close #8.

The logic for parsing is much more complicated than the other week formats (`%W` and `%U`), so I wasn't quite sure how to fit it in. Any new commits or suggestions of refactoring/rewriting are welcome 😄 