### PR TITLE
ISO Week Year (%g and %G)

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -33,6 +33,18 @@ function newYear(y) {
   return {y: y, m: 0, d: 1, H: 0, M: 0, S: 0, L: 0};
 }
 
+function weekNumberISO(d) {
+  var day = d.getDay();
+  d = (day >= 4 || day === 0) ? timeThursday(d) : timeThursday.ceil(d);
+  return timeThursday.count(timeYear(d), d) + (timeYear(d).getDay() === 4);
+}
+
+function utcWeekNumberISO(d) {
+  var day = d.getUTCDay();
+  d = (day >= 4 || day === 0) ? utcThursday(d) : utcThursday.ceil(d);
+  return utcThursday.count(utcYear(d), d) + (utcYear(d).getUTCDay() === 4);
+}
+
 export default function formatLocale(locale) {
   var locale_dateTime = locale.dateTime,
       locale_date = locale.date,
@@ -63,6 +75,8 @@ export default function formatLocale(locale) {
     "d": formatDayOfMonth,
     "e": formatDayOfMonth,
     "f": formatMicroseconds,
+    "g": formatISOWeekYear,
+    "G": formatISOWeekFullYear,
     "H": formatHour24,
     "I": formatHour12,
     "j": formatDayOfYear,
@@ -95,6 +109,8 @@ export default function formatLocale(locale) {
     "d": formatUTCDayOfMonth,
     "e": formatUTCDayOfMonth,
     "f": formatUTCMicroseconds,
+    "g": formatUTCISOWeekYear,
+    "G": formatUTCISOWeekFullYear,
     "H": formatUTCHour24,
     "I": formatUTCHour12,
     "j": formatUTCDayOfYear,
@@ -528,9 +544,7 @@ function formatWeekNumberSunday(d, p) {
 }
 
 function formatWeekNumberISO(d, p) {
-  var day = d.getDay();
-  d = (day >= 4 || day === 0) ? timeThursday(d) : timeThursday.ceil(d);
-  return pad(timeThursday.count(timeYear(d), d) + (timeYear(d).getDay() === 4), p, 2);
+  return pad(weekNumberISO(d), p, 2);
 }
 
 function formatWeekdayNumberSunday(d) {
@@ -539,6 +553,22 @@ function formatWeekdayNumberSunday(d) {
 
 function formatWeekNumberMonday(d, p) {
   return pad(timeMonday.count(timeYear(d), d), p, 2);
+}
+
+function formatISOWeekYear(d, p) {
+  var isoWeek = weekNumberISO(d),
+      isoYear = d.getMonth() === 0 && isoWeek > 6
+        ? d.getFullYear() - 1 : d.getMonth() === 11 && isoWeek < 47
+          ? d.getFullYear() + 1 : d.getFullYear();
+  return pad(isoYear % 100, p, 2);
+}
+
+function formatISOWeekFullYear(d, p) {
+  var isoWeek = weekNumberISO(d),
+      isoYear = d.getMonth() === 0 && isoWeek > 6
+        ? d.getFullYear() - 1 : d.getMonth() === 11 && isoWeek < 47
+          ? d.getFullYear() + 1 : d.getFullYear();
+  return pad(isoYear % 10000, p, 4);
 }
 
 function formatYear(d, p) {
@@ -602,9 +632,7 @@ function formatUTCWeekNumberSunday(d, p) {
 }
 
 function formatUTCWeekNumberISO(d, p) {
-  var day = d.getUTCDay();
-  d = (day >= 4 || day === 0) ? utcThursday(d) : utcThursday.ceil(d);
-  return pad(utcThursday.count(utcYear(d), d) + (utcYear(d).getUTCDay() === 4), p, 2);
+  return pad(utcWeekNumberISO(d), p, 2);
 }
 
 function formatUTCWeekdayNumberSunday(d) {
@@ -613,6 +641,22 @@ function formatUTCWeekdayNumberSunday(d) {
 
 function formatUTCWeekNumberMonday(d, p) {
   return pad(utcMonday.count(utcYear(d), d), p, 2);
+}
+
+function formatUTCISOWeekYear(d, p) {
+  var isoWeek = utcWeekNumberISO(d),
+      isoYear = d.getUTCMonth() === 0 && isoWeek > 6
+        ? d.getUTCFullYear() - 1 : d.getUTCMonth() === 11 && isoWeek < 47
+          ? d.getUTCFullYear() + 1 : d.getUTCFullYear();
+  return pad(isoYear % 100, p, 2);
+}
+
+function formatUTCISOWeekFullYear(d, p) {
+  var isoWeek = utcWeekNumberISO(d),
+      isoYear = d.getUTCMonth() === 0 && isoWeek > 6
+        ? d.getUTCFullYear() - 1 : d.getUTCMonth() === 11 && isoWeek < 47
+          ? d.getUTCFullYear() + 1 : d.getUTCFullYear();
+  return pad(isoYear % 10000, p, 4);
 }
 
 function formatUTCYear(d, p) {

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -110,6 +110,32 @@ tape("timeFormat(\"%e\")(date) formats space-padded dates", function(test) {
   test.end();
 });
 
+tape("timeFormat(\"%g\")(date) formats zero-padded two-digit years", function(test) {
+  var f = timeFormat.timeFormat("%g");
+  test.equal(f(date.local(1990, 0, 1)), "90");
+  test.equal(f(date.local(1990, 11, 31)), "91");
+  test.equal(f(date.local(1991, 0, 1)), "91");
+  test.equal(f(date.local(2015, 11, 31)), "15");
+  test.equal(f(date.local(2016, 0, 1)), "15");
+  test.equal(f(date.local(2016, 0, 2)), "15");
+  test.equal(f(date.local(2016, 0, 3)), "15");
+  test.equal(f(date.local(2016, 0, 4)), "16");
+  test.end();
+});
+
+tape("timeFormat(\"%G\")(date) formats zero-padded four-digit years", function(test) {
+  var f = timeFormat.timeFormat("%G");
+  test.equal(f(date.local(1990, 0, 1)), "1990");
+  test.equal(f(date.local(1990, 11, 31)), "1991");
+  test.equal(f(date.local(1991, 0, 1)), "1991");
+  test.equal(f(date.local(2015, 11, 31)), "2015");
+  test.equal(f(date.local(2016, 0, 1)), "2015");
+  test.equal(f(date.local(2016, 0, 2)), "2015");
+  test.equal(f(date.local(2016, 0, 3)), "2015");
+  test.equal(f(date.local(2016, 0, 4)), "2016");
+  test.end();
+});
+
 tape("timeFormat(\"%H\")(date) formats zero-padded hours (24)", function(test) {
   var f = timeFormat.timeFormat("%H");
   test.equal(f(date.local(1990, 0, 1,  0)), "00");

--- a/test/utcFormat-test.js
+++ b/test/utcFormat-test.js
@@ -98,6 +98,32 @@ tape("utcFormat(\"%e\")(date) formats space-padded dates", function(test) {
   test.end();
 });
 
+tape("utcFormat(\"%g\")(date) formats zero-padded two-digit years", function(test) {
+  var f = timeFormat.utcFormat("%g");
+  test.equal(f(date.utc(1990, 0, 1)), "90");
+  test.equal(f(date.utc(1990, 11, 31)), "91");
+  test.equal(f(date.utc(1991, 0, 1)), "91");
+  test.equal(f(date.utc(2015, 11, 31)), "15");
+  test.equal(f(date.utc(2016, 0, 1)), "15");
+  test.equal(f(date.utc(2016, 0, 2)), "15");
+  test.equal(f(date.utc(2016, 0, 3)), "15");
+  test.equal(f(date.utc(2016, 0, 4)), "16");
+  test.end();
+});
+
+tape("utcFormat(\"%G\")(date) formats zero-padded four-digit years", function(test) {
+  var f = timeFormat.utcFormat("%G");
+  test.equal(f(date.utc(1990, 0, 1)), "1990");
+  test.equal(f(date.utc(1990, 11, 31)), "1991");
+  test.equal(f(date.utc(1991, 0, 1)), "1991");
+  test.equal(f(date.utc(2015, 11, 31)), "2015");
+  test.equal(f(date.utc(2016, 0, 1)), "2015");
+  test.equal(f(date.utc(2016, 0, 2)), "2015");
+  test.equal(f(date.utc(2016, 0, 3)), "2015");
+  test.equal(f(date.utc(2016, 0, 4)), "2016");
+  test.end();
+});
+
 tape("utcFormat(\"%H\")(date) formats zero-padded hours (24)", function(test) {
   var f = timeFormat.utcFormat("%H");
   test.equal(f(date.utc(1990, 0, 1,  0)), "00");


### PR DESCRIPTION
This addresses #42. This PR isn't complete, but is a start towards adding `%G` and `%g`.

I'm having a difficult time figuring out how to best implement parsing `%G` or `%g`, so I would like some feedback on good test cases and approaches I can use for that.

Notes: 
ISO week number formatting logic was extracted into functions as each
is used for three different formats (the week number itself, plus the
additional two ISO week year formats).