### PR TITLE
Add quarter (%q) format directive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Returns a new formatter for the given string *specifier*. The specifier string m
 * `%M` - minute as a decimal number [00,59].
 * `%L` - milliseconds as a decimal number [000, 999].
 * `%p` - either AM or PM.*
+* `%q` - quarter of the year as a decimal number [1,4].
 * `%Q` - milliseconds since UNIX epoch.
 * `%s` - seconds since UNIX epoch.
 * `%S` - second as a decimal number [00,61].

--- a/src/locale.js
+++ b/src/locale.js
@@ -70,6 +70,7 @@ export default function formatLocale(locale) {
     "m": formatMonthNumber,
     "M": formatMinutes,
     "p": formatPeriod,
+    "q": formatQuarter,
     "Q": formatUnixTimestamp,
     "s": formatUnixTimestampSeconds,
     "S": formatSeconds,
@@ -102,6 +103,7 @@ export default function formatLocale(locale) {
     "m": formatUTCMonthNumber,
     "M": formatUTCMinutes,
     "p": formatUTCPeriod,
+    "q": formatUTCQuarter,
     "Q": formatUnixTimestamp,
     "s": formatUnixTimestampSeconds,
     "S": formatUTCSeconds,
@@ -317,6 +319,10 @@ export default function formatLocale(locale) {
     return locale_periods[+(d.getHours() >= 12)];
   }
 
+  function formatQuarter(d) {
+    return 1 + ~~(d.getMonth() / 3);
+  }
+
   function formatUTCShortWeekday(d) {
     return locale_shortWeekdays[d.getUTCDay()];
   }
@@ -335,6 +341,10 @@ export default function formatLocale(locale) {
 
   function formatUTCPeriod(d) {
     return locale_periods[+(d.getUTCHours() >= 12)];
+  }
+
+  function formatUTCQuarter(d) {
+    return 1 + ~~(d.getUTCMonth() / 3);
   }
 
   return {

--- a/test/format-test.js
+++ b/test/format-test.js
@@ -158,6 +158,15 @@ tape("timeFormat(\"%p\")(date) formats AM or PM", function(test) {
   test.end();
 });
 
+tape("timeFormat(\"%q\")(date) formats quarters", function(test) {
+  var f = timeFormat.timeFormat("%q");
+  test.equal(f(date.local(1990, 0, 1)), "1");
+  test.equal(f(date.local(1990, 3, 1)), "2");
+  test.equal(f(date.local(1990, 6, 1)), "3");
+  test.equal(f(date.local(1990, 9, 1)), "4");
+  test.end();
+});
+
 tape("timeFormat(\"%S\")(date) formats zero-padded seconds", function(test) {
   var f = timeFormat.timeFormat("%S");
   test.equal(f(date.local(1990, 0, 1, 0, 0,  0)), "00");

--- a/test/utcFormat-test.js
+++ b/test/utcFormat-test.js
@@ -146,6 +146,15 @@ tape("utcFormat(\"%p\")(date) formats AM or PM", function(test) {
   test.end();
 });
 
+tape("utcFormat(\"%q\")(date) formats quarters", function(test) {
+  var f = timeFormat.utcFormat("%q");
+  test.equal(f(date.utc(1990, 0, 1)), "1");
+  test.equal(f(date.utc(1990, 3, 1)), "2");
+  test.equal(f(date.utc(1990, 6, 1)), "3");
+  test.equal(f(date.utc(1990, 9, 1)), "4");
+  test.end();
+});
+
 tape("utcFormat(\"%Q\")(date) formats UNIX timestamps", function(test) {
   var f = timeFormat.utcFormat("%Q");
   test.equal(f(date.utc(1970, 0, 1,  0,  0,  0)), "0");


### PR DESCRIPTION
Adds support for a quarter (`%q`) directive to the `format` and `utcFormat` methods. This directive is not affected by the locale definition.

- Jan-Mar -> 1
- Apr-Jun -> 2
- Jul-Sep -> 3
- Oct-Dec -> 4

Closes d3/d3-time-format#56.