### PR TITLE
it is a workaround as issue #82

### DIFF
--- a/locale/pt-BR.json
+++ b/locale/pt-BR.json
@@ -2,7 +2,7 @@
   "dateTime": "%A, %e de %B de %Y. %X",
   "date": "%d/%m/%Y",
   "time": "%H:%M:%S",
-  "periods": ["AM", "PM"],
+  "periods": [],
   "days": ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado"],
   "shortDays": ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
   "months": ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],


### PR DESCRIPTION
See ideal solution at [issue #82](https://github.com/d3/d3-time-format/issues/82), that will be a flag `prefer-no-periods: true`.