### PR TITLE
update nl-NL locale dateTime format

### DIFF
--- a/locale/nl-NL.json
+++ b/locale/nl-NL.json
@@ -1,5 +1,5 @@
 {
-  "dateTime": "%a %e %B %Y %T",
+  "dateTime": "%a %e %B %Y %X",
   "date": "%d-%m-%Y",
   "time": "%H:%M:%S",
   "periods": ["AM", "PM"],


### PR DESCRIPTION
The dateTime format "%a %e %B %Y %T" returns strings like 'vr 10 juli 2020 T'.  After that fix it will be like 'vr 10 juli 2020 17:00:00'.