### PR TITLE
export locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
   "jsdelivr": "dist/d3-time-format.min.js",
   "unpkg": "dist/d3-time-format.min.js",
   "exports": {
-    "umd": "./dist/d3-time-format.min.js",
-    "default": "./src/index.js"
+    ".": {
+      "umd": "./dist/d3-time-format.min.js",
+      "default": "./src/index.js"
+    },
+    "./locale/*": "./locale/*.json"
   },
   "sideEffects": [
     "./src/defaultLocale.js"


### PR DESCRIPTION
export all files under locale/xxx.json as "locale/xxx"

the import syntax becomes:
`import localeCh from "d3-time-format/locale/de-CH";`

@herrstucki a bit different from your original usage.


closes #98
