### PR TITLE
export locales without renaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "umd": "./dist/d3-time-format.min.js",
       "default": "./src/index.js"
     },
-    "./locale/*": "./locale/*.json"
+    "./locale/*": "./locale/*"
   },
   "sideEffects": [
     "./src/defaultLocale.js"


### PR DESCRIPTION
This change updates the locale exports to not automatically append the `.json` suffix. The export pattern is a simple matching pattern as described in https://nodejs.org/api/packages.html#subpath-patterns and while friendly, it prohibits TypeScript from consuming the locales with its [`resolveJsonModule`](https://www.typescriptlang.org/tsconfig#resolveJsonModule) option which expect the import to have the `.json` suffix. Because the export is helpfully appending the `.json` suffix this results in a lookup of `./locale/<locale>.json.json` which will then fail.

This PR as proposed is not backwards compatible and only one export can be provided on the left hand side. If backwards compatibility is desired then the packaging scripts can probably create copies of the files at the unsuffixed paths, but I'm not sure if that breaks some other loader that is looking at the resolved filename extension instead of the declared import.

related PR: https://github.com/d3/d3-format/pull/127