### PR TITLE
Use correct year in count() to avoid overflow

### DIFF
--- a/src/locale.js
+++ b/src/locale.js
@@ -560,8 +560,8 @@ function dISO(d) {
 }
 
 function formatWeekNumberISO(d, p) {
-  d = dISO(d);
-  return pad(timeThursday.count(timeYear(d), d) + (timeYear(d).getDay() === 4), p, 2);
+  var dISO = dISO(d);
+  return pad(timeThursday.count(timeYear(d), dISO) + (timeYear(d).getDay() === 4), p, 2);
 }
 
 function formatWeekdayNumberSunday(d) {
@@ -649,8 +649,8 @@ function UTCdISO(d) {
 }
 
 function formatUTCWeekNumberISO(d, p) {
-  d = UTCdISO(d);
-  return pad(utcThursday.count(utcYear(d), d) + (utcYear(d).getUTCDay() === 4), p, 2);
+  var dUTC = UTCdISO(d);
+  return pad(utcThursday.count(utcYear(d), dUTC) + (utcYear(d).getUTCDay() === 4), p, 2);
 }
 
 function formatUTCWeekdayNumberSunday(d) {


### PR DESCRIPTION
I'd like to add a test case for this.

But I'm a bit of a noob in that department... could you explain how to add?

It would be a good test to loop thru every hour of a year and make sure the week number matches the JS.Date() week number